### PR TITLE
Choose secondary slot when both slots are equal

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -566,9 +566,10 @@ find_slot_with_highest_version(struct boot_loader_state *state,
                 rc = boot_version_cmp(
                             &boot_img_hdr(state, slot)->ih_ver,
                             &boot_img_hdr(state, candidate_slot)->ih_ver);
-                if (rc == 1) {
-                    /* The version of the image being examined is greater than
+                if (rc >= 0) {
+                    /* The version of the image being examined is greater or equal than
                      * the version of the current candidate.
+                     * If both are equal, choose the secondary slot.
                      */
                     candidate_slot = slot;
                 }


### PR DESCRIPTION
Previous code chose primary slot, now choose secondary when slots have identical versions & build numbers.