### PR TITLE
Use Scorpio's SHA engine for digest validation in common cases

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -56,6 +56,92 @@
 
 #include "bootutil_priv.h"
 
+#ifdef CONFIG_SCORPIO_BOOTLOADER
+#include "scorpio_crypto_sha.h"
+
+static inline int scorpio_sha256(const void *data, uint32_t data_len, uint8_t *output)
+{
+    // Data length must be an exact multiple of SHA-256 block size
+    assert((data_len & ((512 >> 3) - 1)) == 0);
+
+    // Data length must be more than zero and less than 512 MB
+    assert(data_len > 0 && data_len < (512 << 20));
+
+    // Data must have 64-bit alignment
+    assert(((uintptr_t)data & (sizeof(uint64_t) - 1)) == 0);
+
+    // Use a union to access the data for word and byte swapping
+    const union
+    {
+        uint64_t u64;
+        uint32_t u32[2];
+    } *_data = data;
+
+    SCORPIO_CRYPTO_SHA0_CSRS(sha0_csrs, 0);
+
+    uint32_t block_count;
+    for (block_count = 0; data_len > 0; block_count++, data_len -= 64)
+    {
+        // Wait for the SHA engine to be ready to process another block
+        while (!sha0_csrs->status.fields.ready)
+            ;
+
+        // Write the data for the next block to the SHA engine with swapped words and bytes
+        for (int i = 0; i < 8; i++)
+        {
+            ((volatile uint64_t *)&sha0_csrs->block[0])[i] =
+                ((uint64_t)__builtin_bswap32(_data->u32[1]) << 32) | __builtin_bswap32(_data->u32[0]);
+            _data++;
+        }
+
+        // Tell the SHA engine to process on more SHA-256 block
+        sha0_csrs->control.raw = ((__typeof__(sha0_csrs->control)) {
+                                      .fields.init = block_count == 0 ? 1 : 0,
+                                      .fields.next = block_count > 0 ? 1 : 0,
+                                      .fields.mode = 1,
+                                  })
+                                     .raw;
+    }
+
+    // Wait for the SHA engine to be ready to process another block
+    while (!sha0_csrs->status.fields.ready)
+        ;
+
+    // Write the data for the padding and length block to the SHA engine
+    sha0_csrs->block[0].raw = 0x80000000;
+    for (int i = 1; i < 15; i++)
+    {
+        sha0_csrs->block[i].raw = 0x00000000;
+    }
+    sha0_csrs->block[15].raw = block_count << 9;
+
+    // Tell the SHA engine to process the final SHA-256 block
+    sha0_csrs->control.raw = ((__typeof__(sha0_csrs->control)) {
+                                  .fields.init = 0,
+                                  .fields.next = 1,
+                                  .fields.mode = 1,
+                              })
+                                 .raw;
+
+    // Wait for the SHA engine to have a valid digest
+    while (!(sha0_csrs->status.fields.ready && sha0_csrs->status.fields.valid))
+        ;
+
+    // Copy the digest from the SHA engine to the output array
+    for (int i = 0; i < 32;)
+    {
+        uint32_t digest = sha0_csrs->digest[i >> 2].raw;
+        output[i++]     = digest >> 24;
+        output[i++]     = (digest >> 16) & 0xff;
+        output[i++]     = (digest >> 8) & 0xff;
+        output[i++]     = digest & 0xff;
+    }
+
+    // Return success
+    return 1;
+}
+#endif /* CONFIG_SCORPIO_BOOTLOADER */
+
 /*
  * Compute SHA256 over the image.
  */
@@ -113,6 +199,11 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
     size += hdr->ih_protect_tlv_size;
 
 #ifdef MCUBOOT_RAM_LOAD
+#ifdef CONFIG_SCORPIO_BOOTLOADER
+    if (!seed || (seed_len <= 0))
+        scorpio_sha256((void*)(uint64_t)(hdr->ih_load_addr), size, hash_result);
+    else
+#endif /* CONFIG_SCORPIO_BOOTLOADER */
     bootutil_sha256_update(&sha256_ctx,(void*)(uint64_t)(hdr->ih_load_addr), size);
 #else
     for (off = 0; off < size; off += blk_sz) {
@@ -150,6 +241,11 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
 #endif
         bootutil_sha256_update(&sha256_ctx, tmp_buf, blk_sz);
     }
+#endif /* MCUBOOT_RAM_LOAD */
+#ifdef MCUBOOT_RAM_LOAD
+#ifdef CONFIG_SCORPIO_BOOTLOADER
+    if (seed && (seed_len > 0))
+#endif /* CONFIG_SCORPIO_BOOTLOADER */
 #endif /* MCUBOOT_RAM_LOAD */
     bootutil_sha256_finish(&sha256_ctx, hash_result);
     bootutil_sha256_drop(&sha256_ctx);


### PR DESCRIPTION
This PR uses Scorpio's SHA engine for validating the firmware. Since the (trivial) usage of the SHA engine is for one-shot continuous digest calculations that are multiples of SHA block sizes, the implementation is directly in `image_validate.c` rather than a more general hookup via the `sha256.h` header. The call to `scorpio_sha256()` is specifically utilized if RAM loading is enabled _and_ some additional feature (such as split images) are not used. In those cases, the digest should fall back on the slow path (though this is not tested thoroughly).

With the usage of the SHA engine, the image validation time goes from ~10 seconds to ~1 second.

Also, see https://github.com/recogni/scorpio-fw/issues/1022.